### PR TITLE
Add local libvirt storage pools to hypervisors

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,11 @@ Example Playbook
   roles:
     - role: ansible-role-kvm-host
       owox_kvm_host_install_virt_manager: True
+      libvirt_storage_pools:
+        - prod
+        - test
+        - devel
+
 ```
 
 License

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,4 +2,4 @@
 # defaults file for ansible-role-kvm-host
 
 owox_kvm_host_install_virt_manager: False
-libvirt_storage_pools: []
+# libvirt_storage_pools: []

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,3 +2,4 @@
 # defaults file for ansible-role-kvm-host
 
 owox_kvm_host_install_virt_manager: False
+libvirt_storage_pools: []

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,12 +2,12 @@
 # tasks file for ansible-role-kvm-host
 
 # To be able to test role with virtualbox we have to skip that tasks
-- include: verify_vt_enabled.yml
+- include_tasks: verify_vt_enabled.yml
   when: ansible_virtualization_role != 'guest' and ansible_virtualization_type != 'virtualbox'
   tags:
   - kvm-host
 
-- include: install.yml
+- include_tasks: install.yml
   tags:
   - kvm-host
   - kvm-host:install

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -11,3 +11,5 @@
   tags:
   - kvm-host
   - kvm-host:install
+
+- include_tasks: virt_pools.yml

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -13,4 +13,4 @@
   - kvm-host:install
 
 - include_tasks: virt_pools.yml
-  when: libvirt_storage_pools is defined
+  when: libvirt_storage_pools is defined and libvirt_storage_pools | length > 0

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,12 +2,15 @@
 # tasks file for ansible-role-kvm-host
 
 # To be able to test role with virtualbox we have to skip that tasks
-- include: verify_vt_enabled.yml
+- include_tasks: verify_vt_enabled.yml
   when: ansible_virtualization_role != 'guest' and ansible_virtualization_type != 'virtualbox'
   tags:
   - kvm-host
 
-- include: install.yml
+- include_tasks: install.yml
   tags:
   - kvm-host
   - kvm-host:install
+
+- include_tasks: virt_pools.yml
+  when: libvirt_storage_pools is defined

--- a/tasks/virt_pools.yml
+++ b/tasks/virt_pools.yml
@@ -16,7 +16,7 @@
     name: "{{ item }}"
     xml: '{{ lookup("template", "libvirt_pool.xml") }}'
   loop: "{{ libvirt_storage_pools }}"
-  when: ansible_libvirt_pools |length == 0 or 'ansible_libvirt_pools.{{ item }}.state != "active"'
+  when: ansible_libvirt_pools | length == 0 or ansible_libvirt_pools[item].state != "active"
 
 - name: Let's update list of storagepools
   virt_pool:
@@ -28,7 +28,7 @@
     command: build
     name: "{{ item }}"
   loop: "{{ libvirt_storage_pools }}"
-  when: 'ansible_libvirt_pools.{{ item }}.state | default("new") != "active"'
+  when: (ansible_libvirt_pools[item].state | default("new")) != "active"
 
 - name: Start a storage pool
   virt_pool:
@@ -36,11 +36,11 @@
     state: active
     name: "{{ item }}"
   loop: "{{ libvirt_storage_pools }}"
-  when: 'ansible_libvirt_pools.{{ item }}.state | default("new") != "active"'
+  when: (ansible_libvirt_pools[item].state | default("new")) != "active"
 
 - name: Ensure that a given pool will be started at boot
   virt_pool:
     autostart: yes
     name: "{{ item }}"
   loop: "{{ libvirt_storage_pools }}"
-  when: 'ansible_libvirt_pools.{{ item }}.autostart == "no"'
+  when: (ansible_libvirt_pools[item].autostart) == "no"

--- a/tasks/virt_pools.yml
+++ b/tasks/virt_pools.yml
@@ -1,0 +1,54 @@
+# Gather facts about storage pools
+# Facts will be available as 'ansible_libvirt_pools'
+- name: Check current pools
+  virt_pool:
+    command: facts
+
+- name: Check if we already have pools
+  debug:
+    var: ansible_libvirt_pools.{{ item }}.state
+  loop: "{{ libvirt_storage_pools }}"
+
+
+- name: Define a new storage pool
+  become: true
+  virt_pool:
+    command: define
+    name: "{{ item }}"
+    xml: '{{ lookup("template", "libvirt_pool.xml") }}'
+  loop: "{{ libvirt_storage_pools }}"
+
+- name: Build a storage pool if it does not exist
+  become: true
+  virt_pool:
+    command: build
+    name: "{{ item }}"
+  loop: "{{ libvirt_storage_pools }}"
+  when: 'ansible_libvirt_pools[item]["state"] | default("new") != "active"'
+
+- name: Show states
+  debug:
+    msg: "{{ item }} state is {{ ansible_libvirt_pools[item]['state']}}"
+    # var: ansible_libvirt_pools.item.state
+  loop: "{{ libvirt_storage_pools }}"
+
+- name: Start a storage pool
+  virt_pool:
+    state: active
+    name: "{{ item }}"
+  loop: "{{ libvirt_storage_pools }}"
+  when: 'ansible_libvirt_pools[item]["state"] | default("new") != "active"'
+
+- name: Ensure that pools will be started at boot
+  virt_pool:
+    autostart: true
+    name: "{{ item }}"
+  loop: "{{ libvirt_storage_pools }}"
+
+# - name: Ensure that a given pool will be started at boot
+#   virt_pool:
+#     autostart: yes
+#     name: "{{ item }}"
+#   loop: "{{ libvirt_storage_pools }}"
+
+

--- a/tasks/virt_pools.yml
+++ b/tasks/virt_pools.yml
@@ -28,7 +28,7 @@
     command: build
     name: "{{ item }}"
   loop: "{{ libvirt_storage_pools }}"
-  when: 'ansible_libvirt_pools[item]["state"] | default("new") != "active"'
+  when: 'ansible_libvirt_pools.{{ item }}.state | default("new") != "active"'
 
 - name: Start a storage pool
   virt_pool:
@@ -36,8 +36,7 @@
     state: active
     name: "{{ item }}"
   loop: "{{ libvirt_storage_pools }}"
-  when: 'ansible_libvirt_pools[item]["state"] | default("new") != "active"'
-  when: 'ansible_libvirt_pools.{{ item }}.state != "active"'
+  when: 'ansible_libvirt_pools.{{ item }}.state | default("new") != "active"'
 
 - name: Ensure that a given pool will be started at boot
   virt_pool:
@@ -45,4 +44,3 @@
     name: "{{ item }}"
   loop: "{{ libvirt_storage_pools }}"
   when: 'ansible_libvirt_pools.{{ item }}.autostart == "no"'
-

--- a/tasks/virt_pools.yml
+++ b/tasks/virt_pools.yml
@@ -4,12 +4,6 @@
   virt_pool:
     command: facts
 
-- name: Check if we already have pools
-  debug:
-    var: ansible_libvirt_pools.{{ item }}.state
-  loop: "{{ libvirt_storage_pools }}"
-
-
 - name: Define a new storage pool
   become: true
   virt_pool:
@@ -26,12 +20,6 @@
   loop: "{{ libvirt_storage_pools }}"
   when: 'ansible_libvirt_pools[item]["state"] | default("new") != "active"'
 
-- name: Show states
-  debug:
-    msg: "{{ item }} state is {{ ansible_libvirt_pools[item]['state']}}"
-    # var: ansible_libvirt_pools.item.state
-  loop: "{{ libvirt_storage_pools }}"
-
 - name: Start a storage pool
   virt_pool:
     state: active
@@ -44,11 +32,4 @@
     autostart: true
     name: "{{ item }}"
   loop: "{{ libvirt_storage_pools }}"
-
-# - name: Ensure that a given pool will be started at boot
-#   virt_pool:
-#     autostart: yes
-#     name: "{{ item }}"
-#   loop: "{{ libvirt_storage_pools }}"
-
 

--- a/tasks/virt_pools.yml
+++ b/tasks/virt_pools.yml
@@ -1,0 +1,48 @@
+# Gather facts about storage pools
+# Facts will be available as 'ansible_libvirt_pools'
+- name: Check current pools
+  virt_pool:
+    command: facts
+
+- name: Check if we already have pools
+  debug:
+    var: ansible_libvirt_pools
+  loop: "{{ libvirt_storage_pools }}"
+
+- name: Define a new storage pool
+  become: true
+  virt_pool:
+    command: define
+    name: "{{ item }}"
+    xml: '{{ lookup("template", "libvirt_pool.xml") }}'
+  loop: "{{ libvirt_storage_pools }}"
+  when: ansible_libvirt_pools |length == 0 or 'ansible_libvirt_pools.{{ item }}.state != "active"'
+
+- name: Let's update list of storagepools
+  virt_pool:
+    command: facts
+
+- name: Build a storage pool if it does not exist
+  become: true
+  virt_pool:
+    command: build
+    name: "{{ item }}"
+  loop: "{{ libvirt_storage_pools }}"
+  when: 'ansible_libvirt_pools.{{ item }}.state != "active"'
+
+- name: Start a storage pool
+  virt_pool:
+    autostart: yes
+    state: active
+    name: "{{ item }}"
+  loop: "{{ libvirt_storage_pools }}"
+  when: 'ansible_libvirt_pools.{{ item }}.state != "active"'
+
+- name: Ensure that a given pool will be started at boot
+  virt_pool:
+    autostart: yes
+    name: "{{ item }}"
+  loop: "{{ libvirt_storage_pools }}"
+  when: 'ansible_libvirt_pools.{{ item }}.autostart == "no"'
+ 
+

--- a/templates/libvirt_pool.xml
+++ b/templates/libvirt_pool.xml
@@ -1,0 +1,15 @@
+<pool type='dir'>
+  <name>{{ item }}</name>
+  <source>
+  </source>
+  <target>
+      <path>/var/lib/libvirt/images/{{ item }}</path>
+    <permissions>
+      <mode>0755</mode>
+      <owner>0</owner>
+      <group>0</group>
+      <label>unconfined_u:object_r:virt_image_t:s0</label>
+    </permissions>
+  </target>
+</pool>
+


### PR DESCRIPTION
Before hypervisor didn't get local storage pools by the role, or the had to be created by hand.
With this addition we could add local storage pools with default template after libvirt installation.
This PR shouldn't change role's previous workings, unless libvirt_storage_pools -variable is changed from default (=empty list) value.